### PR TITLE
A spelling fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ### [中文版说明文档](https://github.com/AaronFeng753/Waifu2x-Extension-GUI/blob/master/README_CN.md#waifu2x-extension-gui)
 
 # [Download Latest Build (Windwos x64)](https://github.com/AaronFeng753/Waifu2x-Extension-GUI/releases/latest)
-Download Latest installation(or portable) package for `Windwos x64` PC with `Intel/AMD/Nvidia` GPU.
+Download Latest installation(or portable) package for `Windows x64` PC with `Intel/AMD/Nvidia` GPU.
 
 Download Latest Build: https://github.com/AaronFeng753/Waifu2x-Extension-GUI/releases/latest
 


### PR DESCRIPTION
"Windows" was misspelled as "Windwos".