### PR TITLE
Change time formatting to hh:mm:ss

### DIFF
--- a/SRC_v3.41.01-beta/Waifu2x-Extension-QT/mainwindow.cpp
+++ b/SRC_v3.41.01-beta/Waifu2x-Extension-QT/mainwindow.cpp
@@ -344,11 +344,11 @@ void MainWindow::TimeSlot()
 }
 QString MainWindow::Seconds2hms(long unsigned int seconds)
 {
-    if(seconds<=0)return "0:0:0";
+    if(seconds<=0)return "00:00:00";
     long unsigned int hour = seconds / 3600;
     long unsigned int min = (seconds-(hour*3600))/60;
     long unsigned int sec = seconds - hour*3600 - min*60;
-    return QString::number(hour,10)+":"+QString::number(min,10)+":"+QString::number(sec,10);
+    return QString::asprintf("%02lu:%02lu:%02lu", hour, min, sec);
 }
 
 void MainWindow::Set_Font_fixed()


### PR DESCRIPTION
This is the current way the time is showed in the interface:

![image](https://github.com/AaronFeng753/Waifu2x-Extension-GUI/assets/46503611/92b59007-f9a5-4124-ba7c-acbaab9f1987)

I think, this should be changed to something like:
Time taken:[02:01:58]
Time remaining:[00:33:22]